### PR TITLE
roll up merge of mis-aligned dependencies

### DIFF
--- a/2-Authorization-I/call-graph/pom.xml
+++ b/2-Authorization-I/call-graph/pom.xml
@@ -5,7 +5,7 @@
   <parent> 
     <groupId>org.springframework.boot</groupId>  
     <artifactId>spring-boot-starter-parent</artifactId>  
-    <version>2.4.4</version>  
+    <version>2.5.6</version>  
     <relativePath/>  
     <!-- lookup parent from repository --> 
   </parent>  


### PR DESCRIPTION
- build(deps): bump azure-spring-boot-starter-active-directory
- build(deps): bump spring-boot-starter-parent
- - adds missing guava dependency after merging #10


closes #38, #32, #12
